### PR TITLE
removed extra front slash

### DIFF
--- a/.markdown-link-check.json
+++ b/.markdown-link-check.json
@@ -13,7 +13,7 @@
       "replacement": "https://github.com/STRIDES/NIHCloudLabAzure/tree/main/docs"
     },
     {
-      "pattern": "^/notebooks/",
+      "pattern": "^/notebooks",
       "replacement": "https://github.com/STRIDES/NIHCloudLabAzure/tree/main/notebooks"
     }
 


### PR DESCRIPTION
The extra front slash in the pattern probably is causing the link_check job to fail here.

## Pull Request Template

### Description
<!-- Provide a description of your changes here. If this PR is related to an issue, list the issue number/name here -->
*Provide a description of your changes here. If this PR is related to an issue, list the issue number/name here*

#86 

### Assignee
<!-- Mention the GitHub username of the user you want to assign this PR to -->
*Assignees: @kyleoconnell-NIH*

## PR checklist
*Please ensure the following:*
- [* ] This comment contains a description of changes (with reason).
- [ ] All changes were tested.
- [ *] If you've fixed a bug mention the issue number/name.
- [ ] Apply approriate tags (e.g. documentation, bug)
